### PR TITLE
[JENKINS-43669] Remove Trilead references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.iws
 target
 work
+.idea/

--- a/pom.xml
+++ b/pom.xml
@@ -38,13 +38,13 @@
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>
-      <url>https://repo.jenkins-ci.org</url>
+      <url>https://repo.jenkins-ci.org/public</url>
     </repository>
   </repositories>
   <pluginRepositories>
       <pluginRepository>
           <id>repo.jenkins-ci.org</id>
-          <url>https://repo.jenkins-ci.org</url>
+          <url>https://repo.jenkins-ci.org/public</url>
       </pluginRepository>
   </pluginRepositories>
 


### PR DESCRIPTION
[JENKINS-43669](https://issues.jenkins-ci.org/browse/JENKINS-43669) Remove Trilead references from ssh-cli-auth module