### PR TITLE
[JENKINS-43669] Remove Trilead references in SSH CLI Auth Module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.iml
 *.ipr
 *.iws
+.idea
 target
 work

--- a/src/main/java/org/jenkinsci/main/modules/cli/auth/ssh/KeyEncodeHelper.java
+++ b/src/main/java/org/jenkinsci/main/modules/cli/auth/ssh/KeyEncodeHelper.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jenkinsci.main.modules.cli.auth.ssh;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.math.BigInteger;
+import java.nio.charset.Charset;
+
+
+/**
+ * This class help to encode RSA and DSA keys to OpenSSH format
+ * Methods came from Apache Mina SSH classes
+ * https://github.com/apache/mina-sshd/blob/master/sshd-common/src/main/java/org/apache/sshd/common/config/keys/impl/DSSPublicKeyEntryDecoder.java
+ * https://github.com/apache/mina-sshd/blob/master/sshd-common/src/main/java/org/apache/sshd/common/config/keys/impl/RSAPublicKeyDecoder.java
+ * https://github.com/apache/mina-sshd/blob/master/sshd-common/src/main/java/org/apache/sshd/common/config/keys/KeyEntryResolver.java
+ */
+public class KeyEncodeHelper {
+
+    public static int encodeBigInt(OutputStream s, BigInteger v) throws IOException {
+        byte[] bytes = v.toByteArray();
+        return writeRLEBytes(s, bytes, 0, bytes.length);
+    }
+
+    public static byte[] encodeInt(OutputStream s, int v) throws IOException {
+        byte[] bytes = {
+                (byte) ((v >> 24) & 0xFF),
+                (byte) ((v >> 16) & 0xFF),
+                (byte) ((v >> 8) & 0xFF),
+                (byte) (v & 0xFF)
+        };
+        s.write(bytes);
+        return bytes;
+    }
+
+    public static int encodeString(OutputStream s, String v, Charset cs) throws IOException {
+        byte[] bytes = v.getBytes(cs);
+        return writeRLEBytes(s, bytes, 0, bytes.length);
+    }
+
+    public static int writeRLEBytes(OutputStream s, byte[] bytes, int off, int len) throws IOException {
+        byte[] lenBytes = encodeInt(s, len);
+        s.write(bytes, off, len);
+        return lenBytes.length + len;
+    }
+}

--- a/src/main/java/org/jenkinsci/main/modules/cli/auth/ssh/PublicKeySignatureWriter.java
+++ b/src/main/java/org/jenkinsci/main/modules/cli/auth/ssh/PublicKeySignatureWriter.java
@@ -25,9 +25,6 @@ package org.jenkinsci.main.modules.cli.auth.ssh;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
-import java.math.BigInteger;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.security.interfaces.DSAParams;
 import java.security.interfaces.DSAPublicKey;
@@ -44,66 +41,31 @@ public class PublicKeySignatureWriter {
         throw new IllegalArgumentException("Unknown key type: " + key);
     }
 
-    /*
-     * copied from https://github.com/apache/mina-sshd/blob/master/sshd-common/src/main/java/org/apache/sshd/common/config/keys/impl/DSSPublicKeyEntryDecoder.java
-     */
     public String asString(DSAPublicKey key) {
         try {
             ByteArrayOutputStream output = new ByteArrayOutputStream();
             DSAParams keyParams = Objects.requireNonNull(key.getParams(), "No DSA params available");
-            encodeString(output, "ssh-dss", StandardCharsets.UTF_8);
-            encodeBigInt(output, keyParams.getP());
-            encodeBigInt(output, keyParams.getQ());
-            encodeBigInt(output, keyParams.getG());
-            encodeBigInt(output, key.getY());
+            KeyEncodeHelper.encodeString(output, "ssh-dss", StandardCharsets.UTF_8);
+            KeyEncodeHelper.encodeBigInt(output, keyParams.getP());
+            KeyEncodeHelper.encodeBigInt(output, keyParams.getQ());
+            KeyEncodeHelper.encodeBigInt(output, keyParams.getG());
+            KeyEncodeHelper.encodeBigInt(output, key.getY());
             return new String(output.toByteArray(), StandardCharsets.UTF_8);
         } catch(IOException e) {
             throw new Error(e);
         }
     }
 
-    /*
-     * copied from https://github.com/apache/mina-sshd/blob/master/sshd-common/src/main/java/org/apache/sshd/common/config/keys/impl/RSAPublicKeyDecoder.java
-     */
     public String asString(RSAPublicKey key) {
         try {
             ByteArrayOutputStream output = new ByteArrayOutputStream();
-            encodeString(output, "ssh-rsa", StandardCharsets.UTF_8);
-            encodeBigInt(output, key.getPublicExponent());
-            encodeBigInt(output, key.getModulus());
+            KeyEncodeHelper.encodeString(output, "ssh-rsa", StandardCharsets.UTF_8);
+            KeyEncodeHelper.encodeBigInt(output, key.getPublicExponent());
+            KeyEncodeHelper.encodeBigInt(output, key.getModulus());
             return new String(output.toByteArray(), StandardCharsets.UTF_8);
         } catch(IOException e) {
             throw new Error(e);
         }
     }
 
-    /*
-     * copied from https://github.com/apache/mina-sshd/blob/master/sshd-common/src/main/java/org/apache/sshd/common/config/keys/KeyEntryResolver.java
-     */
-    private int encodeString(OutputStream s, String v, Charset cs) throws IOException {
-        byte[] bytes = v.getBytes(cs);
-        return writeRLEBytes(s, bytes, 0, bytes.length);
-    }
-
-    private int encodeBigInt(OutputStream s, BigInteger v) throws IOException {
-        byte[] bytes = v.toByteArray();
-        return writeRLEBytes(s, bytes, 0, bytes.length);
-    }
-
-    private int writeRLEBytes(OutputStream s, byte[] bytes, int off, int len) throws IOException {
-        byte[] lenBytes = encodeInt(s, len);
-        s.write(bytes, off, len);
-        return lenBytes.length + len;
-    }
-
-    private byte[] encodeInt(OutputStream s, int v) throws IOException {
-        byte[] bytes = {
-                (byte) ((v >> 24) & 0xFF),
-                (byte) ((v >> 16) & 0xFF),
-                (byte) ((v >> 8) & 0xFF),
-                (byte) (v & 0xFF)
-        };
-        s.write(bytes);
-        return bytes;
-    }
 }

--- a/src/main/java/org/jenkinsci/main/modules/cli/auth/ssh/PublicKeySignatureWriter.java
+++ b/src/main/java/org/jenkinsci/main/modules/cli/auth/ssh/PublicKeySignatureWriter.java
@@ -52,7 +52,7 @@ public class PublicKeySignatureWriter {
             KeyEncodeHelper.encodeBigInt(output, key.getY());
             return new String(output.toByteArray(), StandardCharsets.UTF_8);
         } catch(IOException e) {
-            throw new Error(e);
+            throw new PublicKeySignatureWriterException(e);
         }
     }
 
@@ -64,7 +64,7 @@ public class PublicKeySignatureWriter {
             KeyEncodeHelper.encodeBigInt(output, key.getModulus());
             return new String(output.toByteArray(), StandardCharsets.UTF_8);
         } catch(IOException e) {
-            throw new Error(e);
+            throw new PublicKeySignatureWriterException(e);
         }
     }
 

--- a/src/main/java/org/jenkinsci/main/modules/cli/auth/ssh/PublicKeySignatureWriter.java
+++ b/src/main/java/org/jenkinsci/main/modules/cli/auth/ssh/PublicKeySignatureWriter.java
@@ -23,13 +23,18 @@
  */
 package org.jenkinsci.main.modules.cli.auth.ssh;
 
-import java.security.PublicKey;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.math.BigInteger;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.security.interfaces.DSAParams;
 import java.security.interfaces.DSAPublicKey;
 import java.security.interfaces.RSAPublicKey;
+import java.security.PublicKey;
+import java.util.Objects;
 
-import com.trilead.ssh2.crypto.Base64;
-import com.trilead.ssh2.packets.TypesWriter;
 
 public class PublicKeySignatureWriter {
 
@@ -39,26 +44,66 @@ public class PublicKeySignatureWriter {
         throw new IllegalArgumentException("Unknown key type: " + key);
     }
 
+    /*
+     * copied from https://github.com/apache/mina-sshd/blob/master/sshd-common/src/main/java/org/apache/sshd/common/config/keys/impl/DSSPublicKeyEntryDecoder.java
+     */
     public String asString(DSAPublicKey key) {
-        TypesWriter tw = new TypesWriter();
-        tw.writeString("ssh-dss");
-        DSAParams p = key.getParams();
-        tw.writeMPInt(p.getP());
-        tw.writeMPInt(p.getQ());
-        tw.writeMPInt(p.getG());
-        tw.writeMPInt(key.getY());
-        return encode(tw);
+        try {
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            DSAParams keyParams = Objects.requireNonNull(key.getParams(), "No DSA params available");
+            encodeString(output, "ssh-dss", StandardCharsets.UTF_8);
+            encodeBigInt(output, keyParams.getP());
+            encodeBigInt(output, keyParams.getQ());
+            encodeBigInt(output, keyParams.getG());
+            encodeBigInt(output, key.getY());
+            return new String(output.toByteArray(), StandardCharsets.UTF_8);
+        } catch(IOException e) {
+            throw new Error(e);
+        }
     }
 
+    /*
+     * copied from https://github.com/apache/mina-sshd/blob/master/sshd-common/src/main/java/org/apache/sshd/common/config/keys/impl/RSAPublicKeyDecoder.java
+     */
     public String asString(RSAPublicKey key) {
-        TypesWriter tw = new TypesWriter();
-        tw.writeString("ssh-rsa");
-        tw.writeMPInt(key.getPublicExponent());
-        tw.writeMPInt(key.getModulus());
-        return encode(tw);
+        try {
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            encodeString(output, "ssh-rsa", StandardCharsets.UTF_8);
+            encodeBigInt(output, key.getPublicExponent());
+            encodeBigInt(output, key.getModulus());
+            return new String(output.toByteArray(), StandardCharsets.UTF_8);
+        } catch(IOException e) {
+            throw new Error(e);
+        }
     }
 
-    private String encode(TypesWriter tw) {
-        return new String(Base64.encode(tw.getBytes()));
+    /*
+     * copied from https://github.com/apache/mina-sshd/blob/master/sshd-common/src/main/java/org/apache/sshd/common/config/keys/KeyEntryResolver.java
+     */
+    private int encodeString(OutputStream s, String v, Charset cs) throws IOException {
+        byte[] bytes = v.getBytes(cs);
+        return writeRLEBytes(s, bytes, 0, bytes.length);
+    }
+
+    private int encodeBigInt(OutputStream s, BigInteger v) throws IOException {
+        byte[] bytes = v.toByteArray();
+        return writeRLEBytes(s, bytes, 0, bytes.length);
+    }
+
+    private int writeRLEBytes(OutputStream s, byte[] bytes, int off, int len) throws IOException {
+        byte[] lenBytes = encodeInt(s, len);
+        s.write(bytes, off, len);
+        return lenBytes.length + len;
+    }
+
+    private byte[] encodeInt(OutputStream s, int v) throws IOException {
+        byte[] bytes = {
+                (byte) ((v >> 24) & 0xFF),
+                (byte) ((v >> 16) & 0xFF),
+                (byte) ((v >> 8) & 0xFF),
+                (byte) (v & 0xFF)
+        };
+        s.write(bytes);
+        return bytes;
     }
 }

--- a/src/main/java/org/jenkinsci/main/modules/cli/auth/ssh/PublicKeySignatureWriterException.java
+++ b/src/main/java/org/jenkinsci/main/modules/cli/auth/ssh/PublicKeySignatureWriterException.java
@@ -1,0 +1,32 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013 Red Hat, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.main.modules.cli.auth.ssh;
+
+public class PublicKeySignatureWriterException extends RuntimeException {
+
+    public PublicKeySignatureWriterException(Throwable e) {
+        super(e);
+    }
+}


### PR DESCRIPTION
[JENKINS-43669](https://issues.jenkins-ci.org/browse/JENKINS-43669) Remove Trilead references from ssh-cli-auth module

The implementation was copied from the [Apache Mina project](https://github.com/apache/mina-sshd) 

replaces https://github.com/jenkinsci/ssh-cli-auth-module/pull/5

@dwnusbaum @Wadeck @jglick @oleg-nenashev @batmat 