### PR TITLE
JCasC compatibility for authorized keys user property

### DIFF
--- a/src/main/java/org/jenkinsci/main/modules/cli/auth/ssh/UserPropertyImpl.java
+++ b/src/main/java/org/jenkinsci/main/modules/cli/auth/ssh/UserPropertyImpl.java
@@ -34,13 +34,6 @@ public class UserPropertyImpl extends UserProperty {
         return isAuthorizedKey(signature.asString(pk));
     }
 
-    /**
-     * Gets the users authorized keys
-     */
-    public String getAuthorizedKeys() {
-        return authorizedKeys;
-    }
-
     public boolean isAuthorizedKey(String sig) {
         try {
             final BufferedReader r = new BufferedReader(new StringReader(authorizedKeys));

--- a/src/main/java/org/jenkinsci/main/modules/cli/auth/ssh/UserPropertyImpl.java
+++ b/src/main/java/org/jenkinsci/main/modules/cli/auth/ssh/UserPropertyImpl.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.security.PublicKey;
 
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 
@@ -33,6 +34,13 @@ public class UserPropertyImpl extends UserProperty {
         return isAuthorizedKey(signature.asString(pk));
     }
 
+    /**
+     * Gets the users authorized keys
+     */
+    public String getAuthorizedKeys() {
+        return authorizedKeys;
+    }
+
     public boolean isAuthorizedKey(String sig) {
         try {
             final BufferedReader r = new BufferedReader(new StringReader(authorizedKeys));
@@ -49,6 +57,7 @@ public class UserPropertyImpl extends UserProperty {
     }
 
     @Extension
+    @Symbol("sshPublicKey")
     public static final class DescriptorImpl extends UserPropertyDescriptor {
         public String getDisplayName() {
             return "SSH Public Keys";


### PR DESCRIPTION
See https://github.com/jenkinsci/configuration-as-code-plugin/pull/1309

This adds support for configuring authorizedKeys in a users profile,

e.g.

```yaml
jenkins:
  securityRealm:
    local:
      allowsSignup: true
      enableCaptcha: false
      users:
      - description: "I am admin"
        id: "admin"
        name: "Admin"
        properties:
        - sshPublicKey:
            authorizedKeys: |
              ssh-rsa some-key
```